### PR TITLE
Attribute laziness for Moose.

### DIFF
--- a/lib/Test/HTML/Spelling.pm
+++ b/lib/Test/HTML/Spelling.pm
@@ -446,7 +446,7 @@ sub _text {
 
 	    my $word  = encode($encoding, $u_word);
 
-	    my $check = $speller->check($word) || looks_like_number($word);
+	    my $check = $speller->check($word) || looks_like_number($word) || $word =~ /^\d+(?:[-'.]\d+)*/;
 	    unless ($check) {
 
 	    	$self->_errors( 1 + $self->_errors );


### PR DESCRIPTION
Hi,

In Moose you need to mark attributes as lazy that depend on other attributes for their defaults.

http://search.cpan.org/~ether/Moose-2.1204/lib/Moose/Manual/Attributes.pod#Laziness

Right now the ignore_words attribute is used by the tokenizer attribute, and since order of initialization isn't specified by Moose ignore_words was returning undefined, causing the constructor of Search::Tokenize to throw an error.

This pull requests add the proper laziness flags to the attributes.

Thanks,

Rusty
